### PR TITLE
BitBang and no Adafruit_GFX

### DIFF
--- a/Max72xxPanel.cpp
+++ b/Max72xxPanel.cpp
@@ -14,7 +14,6 @@
  All text above must be included in any redistribution.
  ******************************************************************/
 
-#include <Adafruit_GFX.h>
 #include "Max72xxPanel.h"
 #include <SPI.h>
 
@@ -34,7 +33,14 @@
 #define OP_SHUTDOWN    12
 #define OP_DISPLAYTEST 15
 
-Max72xxPanel::Max72xxPanel(byte csPin, byte hDisplays, byte vDisplays) : Adafruit_GFX(hDisplays << 3, vDisplays << 3) {
+#ifndef Panel_No_Adafruit
+  Max72xxPanel::Max72xxPanel(byte csPin, byte hDisplays, byte vDisplays) : Adafruit_GFX(hDisplays << 3, vDisplays << 3) {
+#else
+  Max72xxPanel::Max72xxPanel(byte csPin, byte hDisplays, byte vDisplays) {
+
+  WIDTH = hDisplays << 3;
+  HEIGHT = vDisplays << 3;
+#endif
 
   Max72xxPanel::SPI_CS = csPin;
 
@@ -83,9 +89,11 @@ void Max72xxPanel::setRotation(byte display, byte rotation) {
 	matrixRotation[display] = rotation;
 }
 
+#ifndef Panel_No_Adafruit
 void Max72xxPanel::setRotation(uint8_t rotation) {
 	Adafruit_GFX::setRotation(rotation);
 }
+#endif
 
 void Max72xxPanel::shutdown(boolean b) {
   spiTransfer(OP_SHUTDOWN, b ? 0 : 1);
@@ -107,6 +115,7 @@ void Max72xxPanel::drawPixel(int16_t xx, int16_t yy, uint16_t color) {
 	byte y = yy;
 	byte tmp;
 
+#ifndef Panel_No_Adafruit
 	if ( rotation ) {
 		// Implement Adafruit's rotation.
 		if ( rotation >= 2 ) {										// rotation == 2 || rotation == 3
@@ -121,6 +130,7 @@ void Max72xxPanel::drawPixel(int16_t xx, int16_t yy, uint16_t color) {
 			tmp = x; x = y; y = tmp;
 		}
 	}
+#endif
 
 	if ( x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT ) {
 		// Ignore pixels outside the canvas.

--- a/Max72xxPanel.h
+++ b/Max72xxPanel.h
@@ -27,7 +27,14 @@
  * Uncomment the following line if you do not want to 
  * include the Adafruit_GFX class. 
 */
-#define Panel_No_Adafruit
+// #define Panel_No_Adafruit
+
+/* 
+ * Uncomment the following line if you do not want to use
+ * the SPI library and do bit-banging transfer instead
+ * (E.g. because the SPI interface is already used by other hardware.)
+*/
+#define BitBang_SPI
 
 #if (ARDUINO >= 100)
   #include <Arduino.h>
@@ -52,7 +59,8 @@ public:
    * hDisplays  number of displays horizontally
    * vDisplays  number of displays vertically
    */
-  Max72xxPanel(byte csPin, byte hDisplays=1, byte vDisplays=1);
+    //Max72xxPanel(byte csPin, byte hDisplays=1, byte vDisplays=1);
+    Max72xxPanel(byte csPin, byte hDisplays=1, byte vDisplays=1, byte dataPin=0, byte clkPin=0);
 
   /*
    * Define how the displays are ordered. The first display (0)
@@ -121,9 +129,15 @@ private:
   void spiTransfer(byte opcode, byte data=0);
 
 #ifdef Panel_No_Adafruit
-  /* Panel width and height in pixels, usually part of the Adafruit class. */
+  /* Panel width and height in pixels, otherwise part of the Adafruit class. */
   int WIDTH, HEIGHT;
 #endif
+
+#ifdef BitBang_SPI
+  /* pin numbers for data (Master-Out-Slave-In) and Clock */
+  byte SPI_MOSI, SPI_CLK;
+#endif
+
 
   /* We keep track of the led-status for 8 devices in this array */
   byte *bitmap;

--- a/Max72xxPanel.h
+++ b/Max72xxPanel.h
@@ -34,7 +34,7 @@
  * the SPI library and do bit-banging transfer instead
  * (E.g. because the SPI interface is already used by other hardware.)
 */
-#define BitBang_SPI
+// #define BitBang_SPI
 
 #if (ARDUINO >= 100)
   #include <Arduino.h>

--- a/Max72xxPanel.h
+++ b/Max72xxPanel.h
@@ -14,12 +14,20 @@
  BSD license, check license.txt for more information.
  All text above must be included in any redistribution.
 
+ "Panel_No_Adafruit" extension by Andreas Horneffer, 2016
+
  Datasheet: http://datasheets.maximintegrated.com/en/ds/MAX7219-MAX7221.pdf
 
  ******************************************************************/
 
 #ifndef Max72xxPanel_h
 #define Max72xxPanel_h
+
+/* 
+ * Uncomment the following line if you do not want to 
+ * include the Adafruit_GFX class. 
+*/
+#define Panel_No_Adafruit
 
 #if (ARDUINO >= 100)
   #include <Arduino.h>
@@ -28,41 +36,48 @@
   #include "pins_arduino.h"
 #endif
 
-class Max72xxPanel : public Adafruit_GFX {
+#ifndef Panel_No_Adafruit
+  #include <Adafruit_GFX.h>
+  class Max72xxPanel : public Adafruit_GFX {
+#else
+  class Max72xxPanel {
+#endif
 
 public:
 
   /*
    * Create a new controler
    * Parameters:
-   * csPin		pin for selecting the device
+   * csPin              pin for selecting the device
    * hDisplays  number of displays horizontally
    * vDisplays  number of displays vertically
    */
   Max72xxPanel(byte csPin, byte hDisplays=1, byte vDisplays=1);
 
-	/*
-	 * Define how the displays are ordered. The first display (0)
-	 * is the one closest to the Arduino.
-	 */
-	void setPosition(byte display, byte x, byte y);
+  /*
+   * Define how the displays are ordered. The first display (0)
+   * is the one closest to the Arduino.
+   */
+  void setPosition(byte display, byte x, byte y);
 
-	/*
-	 * Define if and how the displays are rotated. The first display
-	 * (0) is the one closest to the Arduino. rotation can be:
-	 *   0: no rotation
-	 *   1: 90 degrees clockwise
-	 *   2: 180 degrees
-	 *   3: 90 degrees counter clockwise
-	 */
-	void setRotation(byte display, byte rotation);
+  /*
+   * Define if and how the displays are rotated. The first display
+   * (0) is the one closest to the Arduino. rotation can be:
+   *   0: no rotation
+   *   1: 90 degrees clockwise
+   *   2: 180 degrees
+   *   3: 90 degrees counter clockwise
+   */
+  void setRotation(byte display, byte rotation);
 
-	/*
-	 * Implementation of Adafruit's setRotation(). Probably, you don't
-	 * need this function as you can achieve the same result by using
-	 * the previous two functions.
-	 */
-	void setRotation(byte rotation);
+#ifndef Panel_No_Adafruit
+  /*
+   * Implementation of Adafruit's setRotation(). Probably, you don't
+   * need this function as you can achieve the same result by using
+   * the previous two functions.
+   */
+  void setRotation(byte rotation);
+#endif
 
   /*
    * Draw a pixel on your canvas. Note that for performance reasons,
@@ -81,15 +96,15 @@ public:
   /*
    * Set the shutdown (power saving) mode for the device
    * Paramaters:
-   * status	If true the device goes into power-down mode. Set to false
-   *		for normal operation.
+   * status     If true the device goes into power-down mode. Set to false
+   *            for normal operation.
    */
   void shutdown(boolean status);
 
   /*
    * Set the brightness of the display.
    * Paramaters:
-   * intensity	the brightness of the display. (0..15)
+   * intensity  the brightness of the display. (0..15)
    */
   void setIntensity(byte intensity);
 
@@ -105,6 +120,11 @@ private:
   /* Send out a single command to the device */
   void spiTransfer(byte opcode, byte data=0);
 
+#ifdef Panel_No_Adafruit
+  /* Panel width and height in pixels, usually part of the Adafruit class. */
+  int WIDTH, HEIGHT;
+#endif
+
   /* We keep track of the led-status for 8 devices in this array */
   byte *bitmap;
   byte bitmapSize;
@@ -114,7 +134,7 @@ private:
   byte *matrixRotation;
 };
 
-#endif	// Max72xxPanel_h
+#endif  // Max72xxPanel_h
 
 
 

--- a/Max72xxPanel.h
+++ b/Max72xxPanel.h
@@ -55,9 +55,14 @@ public:
   /*
    * Create a new controler
    * Parameters:
-   * csPin              pin for selecting the device
-   * hDisplays  number of displays horizontally
-   * vDisplays  number of displays vertically
+   * csPin         pin for selecting the device
+   * hDisplays     number of displays horizontally
+   * vDisplays     number of displays vertically
+   * NOTE: The last two parameters are only used when using bit-banging! When using the 
+   *       SPI library (the default!) these values are ignored and you need to check the 
+   *       documentation of your hardware to see which pins you need to connect the Max72xx to.
+   * dataPin       pin used to transfer the data when using bit-banging
+   * clkPin        pin used for the clock when using bit-banging
    */
     //Max72xxPanel(byte csPin, byte hDisplays=1, byte vDisplays=1);
     Max72xxPanel(byte csPin, byte hDisplays=1, byte vDisplays=1, byte dataPin=0, byte clkPin=0);


### PR DESCRIPTION
I made two changes to the library that may or may not be of interest for others:
One is to change the communication with the Max72xx from the SPI library, which uses the built-in UART and thus needs to certain pins, to using bit-banging which can use any pins.
The other is to optionally remove the inheritance on the Adafruit_GFX library. This makes the panel into a dumb, framebuffer-like panel without all the functionality from the Adafruit_GFX library. But it also makes the image a lot smaller.

Both changes require a define to be set in the `Max72xxPanel.h` file and a recompilation of the library to take effect.