### PR TITLE
Pulic method to allow matrix reinitialization

### DIFF
--- a/Max72xxPanel.cpp
+++ b/Max72xxPanel.cpp
@@ -59,20 +59,7 @@ Max72xxPanel::Max72xxPanel(byte csPin, byte hDisplays, byte vDisplays) : Adafrui
   // Clear the screen
   fillScreen(0);
 
-  // Make sure we are not in test mode
-  spiTransfer(OP_DISPLAYTEST, 0);
-
-  // We need the multiplexer to scan all segments
-  spiTransfer(OP_SCANLIMIT, 7);
-
-  // We don't want the multiplexer to decode segments for us
-  spiTransfer(OP_DECODEMODE, 0);
-
-  // Enable display
-  shutdown(false);
-
-  // Set the brightness to a medium value
-  setIntensity(7);
+  reset();
 }
 
 void Max72xxPanel::setPosition(byte display, byte x, byte y) {
@@ -192,4 +179,22 @@ void Max72xxPanel::spiTransfer(byte opcode, byte data) {
 
 	// Latch the data onto the display(s)
 	digitalWrite(SPI_CS, HIGH);
+}
+
+void Max72xxPanel::reset(){
+  // Make sure we are not in test mode
+  spiTransfer(OP_DISPLAYTEST, 0);
+
+  // We need the multiplexer to scan all segments
+  spiTransfer(OP_SCANLIMIT, 7);
+
+  // We don't want the multiplexer to decode segments for us
+  spiTransfer(OP_DECODEMODE, 0);
+
+  // Enable display
+  shutdown(false);
+
+  // Set the brightness to a medium value
+  setIntensity(7);
+
 }

--- a/Max72xxPanel.h
+++ b/Max72xxPanel.h
@@ -99,6 +99,12 @@ public:
    */
   void write();
 
+  /*
+   * Reset the matrix modules to a default state,
+   * performed during initialization
+   */
+  void reset();
+
 private:
   byte SPI_CS; /* SPI chip selection */
 


### PR DESCRIPTION
Sometimes happens that a line-shaped artefacts appears on some modules. It might be glitches or noises but the only way to clear it is either to reset the controller or to send initialization OPcodes to the modules.
This change exposes public method that allows to reinitialize matrixes without the need to recreate the object.